### PR TITLE
gradle 오타 수정, protoc 코드 생성위치 변경, 자동생성 source 폴더 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 build/
 out/
 
+.settings/
+bin/
+gen-src/
+.classpath
+.project

--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,7 @@ protobuf {
 dependencies {
     compile 'io.grpc:grpc-netty:1.16.1'
     compile 'io.grpc:grpc-protobuf:1.16.1'
-    compile 'io.grpc:grpc-stub:1.6.1'
+    compile 'io.grpc:grpc-stub:1.16.1'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ buildscript {
 protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:3.6.1"
+
+        // Set the location of generated source code by protoc compiler
+        generatedFilesBaseDir = "$projectDir/gen-src"
     }
     plugins {
         grpc {
@@ -34,6 +37,16 @@ protobuf {
     generateProtoTasks {
         all()*.plugins {
             grpc {}
+        }
+    }
+}
+
+// Add source dir for generated source code of gRPC
+sourceSets {
+    main {
+        java {
+            srcDirs 'gen-src/main/java'
+            srcDirs 'gen-src/main/grpc'
         }
     }
 }


### PR DESCRIPTION
코드 Clone 후 build시 IDE에서 발생하는 컴파일 오류 제거.

- gradle grpc dependencies 버전 오타 수정 
- gradle protoc 설정에 코드 생성위치 지정
- protoc에서 생성한 코드를 source folder로 지정
- etc. gitignore 추가.

※ 이클립스에서 테스트.